### PR TITLE
이원혁 / 2024.07.21, 2024.07.24

### DIFF
--- a/iwonhyeok/11660.java
+++ b/iwonhyeok/11660.java
@@ -1,0 +1,52 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.IOException;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        int[][] matrix = new int[N + 1][N + 1];
+        int[][] matrixSum = new int[N + 1][N + 1];
+
+        // 초기 배열 입력
+        for (int i = 1; i <= N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 1; j <= N; j++) {
+                matrix[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        // 2차원 배열 누적합
+        for (int i = 1; i <= N; i++) {
+            for (int j = 1; j <= N; j++) {
+                matrixSum[i][j] = matrix[i][j] + matrixSum[i - 1][j] + matrixSum[i][j - 1] - matrixSum[i - 1][j - 1];
+            }
+        }
+
+        // 구간합 처리
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int x1 = Integer.parseInt(st.nextToken());
+            int y1 = Integer.parseInt(st.nextToken());
+            int x2 = Integer.parseInt(st.nextToken());
+            int y2 = Integer.parseInt(st.nextToken());
+
+            int result = matrixSum[x2][y2] - matrixSum[x1 - 1][y2] - matrixSum[x2][y1 - 1] + matrixSum[x1 - 1][y1 - 1];
+            bw.write(result + "\n");
+        }
+
+        // 리소스 정리
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}

--- a/iwonhyeok/15651.java
+++ b/iwonhyeok/15651.java
@@ -1,0 +1,48 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.IOException;
+
+public class Main {
+    public static StringBuilder sb = new StringBuilder();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        // 첫 번째 줄에서 N과 M을 입력받음
+        String[] input = br.readLine().split(" ");
+        int N = Integer.parseInt(input[0]);
+        int M = Integer.parseInt(input[1]);
+
+        // M 크기의 배열을 생성하여 순열을 저장
+        int[] sequence = new int[M];
+        // DFS를 사용하여 모든 가능한 순열을 생성
+        dfs(N, M, 0, sequence);
+        // StringBuilder에 저장된 결과를 BufferedWriter로 출력
+        bw.write(sb.toString());
+
+        br.close();
+        bw.flush();
+        bw.close();
+    }
+
+    // 깊이 우선 탐색(DFS) 함수
+    public static void dfs(int N, int M, int depth, int[] sequence) {
+        // 현재 깊이가 M과 같으면 배열의 내용을 StringBuilder에 추가
+        if (depth == M) {
+            for (int num : sequence) {
+                sb.append(num).append(' ');
+            }
+            sb.append('\n');
+            return;
+        }
+
+        // 1부터 N까지의 숫자를 순서대로 배열에 넣고 재귀 호출
+        for (int i = 1; i <= N; i++) {
+            sequence[depth] = i;
+            dfs(N, M, depth + 1, sequence);
+        }
+    }
+}

--- a/iwonhyeok/19951.java
+++ b/iwonhyeok/19951.java
@@ -10,10 +10,9 @@ public class Main {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
 
-        // 첫 번째 줄 입력받기
         StringTokenizer st = new StringTokenizer(br.readLine());
-        int N = Integer.parseInt(st.nextToken());
-        int M = Integer.parseInt(st.nextToken());
+        int N = Integer.parseInt(st.nextToken()); // 연병장의 크기 N
+        int M = Integer.parseInt(st.nextToken()); // 조교 수 M
 
         // 초기 높이 배열 입력받기
         int[] heights = new int[N + 1];

--- a/iwonhyeok/19951.java
+++ b/iwonhyeok/19951.java
@@ -1,0 +1,46 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.IOException;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        // 첫 번째 줄 입력받기
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        // 초기 높이 배열 입력받기
+        int[] heights = new int[N + 1];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+            heights[i] = Integer.parseInt(st.nextToken());
+        }
+
+        // 조교 수만큼 명령 입력받고 시행
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            int k = Integer.parseInt(st.nextToken());
+
+            for (int j = a; j <= b; j++) {
+                heights[j] += k;
+            }
+        }
+
+        // 결과 출력
+        for (int i = 1; i <= N; i++) {
+            bw.write(heights[i] + " ");
+        }
+        // 리소스 정리
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}

--- a/iwonhyeok/2012.java
+++ b/iwonhyeok/2012.java
@@ -1,0 +1,40 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        // 첫 번째 줄에서 N을 입력받음 (학생 수)
+        int N = Integer.parseInt(br.readLine());
+        // 예상 등수를 저장할 배열 생성
+        int[] expectedRanks = new int[N];
+
+        // N개의 예상 등수를 입력받아 배열에 저장
+        for (int i = 0; i < N; i++) {
+            expectedRanks[i] = Integer.parseInt(br.readLine());
+        }
+
+        // 예상 등수를 오름차순으로 정렬
+        Arrays.sort(expectedRanks);
+
+        // 불만도의 합을 계산할 변수
+        long dissatisfactionSum = 0;
+        // 예상 등수와 실제 등수(1부터 N까지)를 비교하여 불만도 계산
+        for (int i = 0; i < N; i++) {
+            dissatisfactionSum += Math.abs(expectedRanks[i] - (i + 1));
+        }
+
+        // 불만도의 합을 출력
+        bw.write(String.valueOf(dissatisfactionSum));
+
+        bw.flush();
+        br.close();
+        bw.close();
+    }
+}

--- a/iwonhyeok/2559-1.java
+++ b/iwonhyeok/2559-1.java
@@ -1,0 +1,42 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.IOException;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken()); // 최대로 입력받을 일 수
+        int K = Integer.parseInt(st.nextToken()); // 누적합 계산할 연속된 일 수
+
+        st = new StringTokenizer(br.readLine());
+        int[] temperatures = new int[N + 1];
+        for (int i = 1; i <= N; i++) {
+            temperatures[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int accSum[] = new int[N + 1];
+        for (int i = 1; i <= N; i++) {
+            accSum[i] = accSum[i - 1] + temperatures[i];
+        }
+
+        int maxSum = -2147483648;
+        for (int i = K; i <= N; i++) {
+            int currentSum = accSum[i] - accSum[i - K];
+            if (currentSum > maxSum) {
+                maxSum = currentSum;
+            }
+        }
+
+        // 결과 출력 및 리소스 정리
+        bw.write(String.valueOf(maxSum));
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}

--- a/iwonhyeok/2559-2.java
+++ b/iwonhyeok/2559-2.java
@@ -1,0 +1,45 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.IOException;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken()); // 최대로 입력받을 일 수
+        int K = Integer.parseInt(st.nextToken()); // 누적합 계산할 연속된 일 수
+
+        st = new StringTokenizer(br.readLine());
+        int[] temperatures = new int[N];
+        for (int i = 0; i < N; i++) {
+            temperatures[i] = Integer.parseInt(st.nextToken());
+        }
+
+        // 초기 K일의 합 계산
+        int maxSum = 0;
+        for (int i = 0; i < K; i++) {
+            maxSum += temperatures[i];
+        }
+
+        int currentSum = maxSum;
+
+        // 누적합을 이용해서 계산
+        for (int i = K; i < N; i++) {
+            currentSum = currentSum + temperatures[i] - temperatures[i - K];
+            if (currentSum > maxSum) {
+                maxSum = currentSum;
+            }
+        }
+
+        // 결과 출력 및 리소스 정리
+        bw.write(String.valueOf(maxSum));
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}


### PR DESCRIPTION
2023.07.21
**2012  등수매기기**
정렬 후 예상등수와 실제등수를 최소화 시켜 불만도를 최소로 함
1. 사람 수 N을 입력받고 N개의 예상등수를 입력받아 배열에 저장함
2. 예상등수가 저장되어 있는 배열을 오름차순 정렬
3. 예상등수와 실제등수를 비교하여 불만도를 계산
4. 불만도를 출력
한가지 모순점은 어떤 사람이 예상등수 3등, 실제등수 1등이라 가정하면 불만도가 2인게(예상등수보다 실제등수가 높아도 불만도가 나온다는게) 문제에서 모순인것 같다.

**15651 N과 M(3)**
1. 자연수 범위 N과 자릿수 M을 입력받은 후 M 크기로 int형 배열 생성
2. dfs(깊이 우선 탐색) 함수 호출
3. for 루프를 통해 1부터 N까지의 숫자를 현재 depth 위치에 넣음
4. sequence[depth] = i를 통해 현재 위치에 숫자를 넣고, depth를 1 증가시켜 dfs를 재귀 호출함  
5. depth가 M에 도달하면, 현재까지 생성된 수열을 출력 형식에 맞게 StringBuilder에 추가하고 함수를 종료
6. 출력 후 리소스 정리

저번 알고리즘 스터디 코드를 안올렸더라구요... 올린줄 알고 있었어요 죄송합니다

2023.07.24
**2559 수열 - 첫번째 풀이**
이전 알고리즘 스터디에서 배운 방식처럼 누적합 배열을 따로 만들고 반복문 통해서 누적합 – 범위 이전의 누적합 =  구하고자 하는 구간 합 이라는 방식으로 풀어봄
1. 최대로 입력 받을 일 수 N과 누적합 계산할 연속된 일 수 M을 입력받음
2. 며칠동안 얻은 온도 데이터를 입력받고 배열에 저장함
3. 누적합 배열에 인덱스 1 부터 N까지 누적합을 구해서 저장
4. (누적합 배열) 구하고자 하는 구간의 마지막 인덱스 - 불필요한 누적합이 현재 저장되어있는 온도 최고값보다 높으면 업데이트
5. 출력 후 리소스 정리

**2559 수열 - 두번째 풀이**
두번째 방법은 누적합 배열을 만들지 않고 입력받은 배열에서 구간합(0~K)을 구한 후 한칸씩 옮겨가며 업데이트 의 방식으로 풀어봄
1. 최대로 입력 받을 일 수 N과 누적합 계산할 연속된 일 수 M을 입력받음
2. 며칠동안 얻은 온도 데이터를 입력받고 배열에 저장함
3. 인덱스 1부터 K까지의 구간합을 구해 온도 최고값으로 초기화
4. 온도 데이터에서 한칸씩 밀면서 구간K개 만큼 더하고 이 값이 온도 최도값보다 높으면 업데이트
5. 출력 후 리소스 정리

**11660 구간 합 구하기 5**
1. 표의 크기 N과 합을 구해야 하는 횟수 M을 입력받음
2. 일반 2차원 배열과 누적합 2차원 배열을 만들고 우선 초기 배열을 입력받고 일반 2차원 배열에 저장
3. 2차원 누적합 배열에 누적합을 구해 저장
4. x1, y1, x2, y2룰 입력받고 구간합을 구해 출력
5. 리소스 정리

**19951 태상이의 훈련소 생활**
조교 수만큼 반복문으로 명령 받고 기존 배열에 업데이트하는 방식으로 풀어봄
1. 연병장의 크기 N과 조교 수 M을 입력받음
2. 초기 배열(연병장의 높이)를 입력받고 배열에 저장함
3. 조교 수 M 만큼 조교의 명령을 받고 연병장의 높이에 업데이트
4. 출력 후 리소스 정리
시간초과로 풀지는 못했지만 결과를 입력해보면 알맞게 나옴 아마 시간복잡도가 n^2라서 시간초과가 뜬거같음 